### PR TITLE
Fix for non-post the_content filter calls

### DIFF
--- a/woocommerce-dotpay.php
+++ b/woocommerce-dotpay.php
@@ -299,7 +299,8 @@ function wc_dotpay_gateway_content($content) {
 			default:
 				return $content;
 		}
-  }
+	}
+	return $content;
 }
 
 /**


### PR DESCRIPTION
Function wc_dotpay_gateway_content that runs the_content filter didn't return $content for non-post type.